### PR TITLE
tests: fix corrupted date header in sample messages

### DIFF
--- a/test/testdata/ham/0359.7f80dc1df7de3b5121e43f29f0a9e911.eml
+++ b/test/testdata/ham/0359.7f80dc1df7de3b5121e43f29f0a9e911.eml
@@ -47,7 +47,7 @@ List-Id: Friends of Rohit Khare <fork.xent.com>
 List-Unsubscribe: <http://xent.com/mailman/listinfo/fork>,
     <mailto:fork-request@xent.com?subject=unsubscribe>
 List-Archive: <http://xent.com/pipermail/fork/>
-Date: Sun, 25 Aug 2002 16:50:54 UT
+Date: Sun, 25 Aug 2002 16:50:54 UTC
 X-Pyzor: Reported 0 times.
 X-Spam-Status: No, hits=-5.6 required=7.0
 	tests=KNOWN_MAILING_LIST,QUOTED_EMAIL_TEXT,SIGNATURE_SHORT_DENSE,

--- a/test/testdata/ham/0361.36332081025aaf122520737c26461a88.eml
+++ b/test/testdata/ham/0361.36332081025aaf122520737c26461a88.eml
@@ -47,7 +47,7 @@ List-Id: Friends of Rohit Khare <fork.xent.com>
 List-Unsubscribe: <http://xent.com/mailman/listinfo/fork>,
     <mailto:fork-request@xent.com?subject=unsubscribe>
 List-Archive: <http://xent.com/pipermail/fork/>
-Date: Mon, 26 Aug 2002 14:13:15 UT
+Date: Mon, 26 Aug 2002 14:13:15 UTC
 X-Pyzor: Reported 0 times.
 X-Spam-Status: No, hits=-5.7 required=7.0
 	tests=KNOWN_MAILING_LIST,QUOTED_EMAIL_TEXT,SIGNATURE_SHORT_DENSE,

--- a/utils_test.go
+++ b/utils_test.go
@@ -38,7 +38,7 @@ func ExampleSort() {
 
 	fmt.Printf("First node subject: %s\n", x.Subject())
 
-	// Output: First node subject: 1970-01-01 00:00:00 +0000 UTC : Re: My source: RE: A biblical digression :: node synthesized by https://gatherstars.com/
+	// Output: First node subject: 2002-02-01 05:44:14 +0000 UTC : Please help a newbie compile mplayer :-)
 }
 
 func ExampleWalk_depth() {


### PR DESCRIPTION
Two sample email files in test/testdata contain corrupted date headers. Since https://github.com/golang/go/commit/3ef8562c9c2c7
 (go 1.19), this invalid date format is somehow parsed successfully. With go 1.18 and earlier, the parsing fails and `Email.GetDate()` returns `time.Unix(0, 0)` (from `jwz_test.go`).

https://github.com/gatherstars-com/jwz/blob/v1.3.0/jwz_test.go#L178-L180

This causes the order of threads to be different in go 1.19 and causes the unit tests to fail.

```
--- FAIL: ExampleSort (0.08s)
got:
First node subject: 2002-02-01 05:44:14 +0000 UTC : Please help a newbie compile mplayer :-)
want:
First node subject: 1970-01-01 00:00:00 +0000 UTC : Re: My source: RE: A biblical digression :: node synthesized by https://gatherstars.com/
```

Fix the corrupted date headers and adjust unit test expected result accordingly.