### PR TITLE
fix: don't add a link if parentRef is already linked to ref

### DIFF
--- a/jwz.go
+++ b/jwz.go
@@ -284,6 +284,7 @@ func (t *Threader) buildContainer(threadable Threadable) error {
 		if parentRef != nil && // there is a parent
 			ref.parent == nil && // don't have a parent already
 			parentRef != ref && // not a tight loop
+			!ref.findChild(parentRef) && // already linked
 			!parentRef.findChild(ref) { // not a wide loop
 
 			// Ok, link it into the parent's child list.

--- a/jwz_test.go
+++ b/jwz_test.go
@@ -367,12 +367,12 @@ func ExampleThreader_ThreadSlice() {
 	//
 	var nc int
 	Count(sliceRoot, &nc)
-	if nc != 2379 {
-		fmt.Printf("expected %d emails after threading, but got %d back", 2379, nc)
+	if nc != 2387 {
+		fmt.Printf("expected %d emails after threading, but got %d back", 2387, nc)
 	} else {
 		fmt.Printf("There are %d test emails", nc)
 	}
-	// Output: There are 2379 test emails
+	// Output: There are 2387 test emails
 }
 
 func TestThreader_ThreadSlice(t1 *testing.T) {
@@ -392,8 +392,8 @@ func TestThreader_ThreadSlice(t1 *testing.T) {
 	//
 	var nc int
 	Count(sliceRoot, &nc)
-	if nc != 2379 {
-		t1.Errorf("expected %d emails after threading, but got %d back", 2379, nc)
+	if nc != 2387 {
+		t1.Errorf("expected %d emails after threading, but got %d back", 2387, nc)
 	}
 }
 
@@ -417,12 +417,12 @@ func ExampleThreader_ThreadRoot() {
 	//
 	var nc int
 	Count(treeRoot, &nc)
-	if nc != 2379 {
-		fmt.Printf("expected %d emails afer threading, but got %d back", 2379, nc)
+	if nc != 2387 {
+		fmt.Printf("expected %d emails afer threading, but got %d back", 2387, nc)
 	} else {
 		fmt.Printf("There are %d test emails", nc)
 	}
-	// Output: There are 2379 test emails
+	// Output: There are 2387 test emails
 }
 
 func TestThreader_ThreadRoot(t1 *testing.T) {
@@ -445,7 +445,7 @@ func TestThreader_ThreadRoot(t1 *testing.T) {
 	//
 	var nc int
 	Count(treeRoot, &nc)
-	if nc != 2379 {
-		t1.Errorf("expected %d emails after threading, but got %d back", 2379, nc)
+	if nc != 2387 {
+		t1.Errorf("expected %d emails after threading, but got %d back", 2387, nc)
 	}
 }

--- a/test/testdata/ham/2552.644f7acacd16eaecc6ff73c9eb2f146d.eml
+++ b/test/testdata/ham/2552.644f7acacd16eaecc6ff73c9eb2f146d.eml
@@ -1,0 +1,13 @@
+From: Person 1 <person1@email.com>
+To: Recipient <recipient@email.com>
+Subject: This is a subject
+Date: Tue, 10 Sep 2019 18:08:16 +0000
+Message-ID:
+ <BYAPR06MB4470CB29D2BFEBAF644020F4DFB60@BYAPR06MB4470.namprd06.prod.outlook.com>
+References:
+ <30105608.20190910123401.5d779839295325.35665885@mail180-17.suw31.mandrillapp.com>
+Mime-Version: 1.0
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset=UTF-8
+
+Test email

--- a/test/testdata/ham/2553.c146fa18e4da75382c84d7d8c6cacc28.eml
+++ b/test/testdata/ham/2553.c146fa18e4da75382c84d7d8c6cacc28.eml
@@ -1,0 +1,14 @@
+Date: Wed, 09 Oct 2019 18:55:01 +0000
+From: Sender <sender@email.com>
+To: Recipient <recipient@email.com>
+Message-ID: <09X9OKXEQW_5d9e2d057f6a7_5fe3fef3e4bcf187145c0_sprut@zendesk.com>
+In-Reply-To: <CAPzZyfsSr9AYg=9seLTYwoKz4qF0M=3r3jsh4tu4UALtRB-+sA@mail.gmail.com>
+References: <09X9OKXEQW@zendesk.com>
+ <BYAPR06MB4470CB29D2BFEBAF644020F4DFB60@BYAPR06MB4470.namprd06.prod.outlook.com>
+ <30105608.20190910123401.5d779839295325.35665885@mail180-17.suw31.mandrillapp.com>
+ <CAPzZyfsSr9AYg=9seLTYwoKz4qF0M=3r3jsh4tu4UALtRB-+sA@mail.gmail.com>
+Subject: Test Subject
+Mime-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+This is an email

--- a/utils_test.go
+++ b/utils_test.go
@@ -66,7 +66,7 @@ func ExampleWalk_depth() {
 
 	fmt.Printf("Walker walked %d depth first\n", c)
 
-	// Output: Walker walked 2379 depth first
+	// Output: Walker walked 2387 depth first
 }
 
 func ExampleWalk_breadth() {
@@ -97,7 +97,7 @@ func ExampleWalk_breadth() {
 
 	fmt.Printf("Walker walked %d depth first\n", c)
 
-	// Output: Walker walked 2379 depth first
+	// Output: Walker walked 2387 depth first
 }
 
 type searcher struct {
@@ -168,5 +168,5 @@ func ExampleCount() {
 	var nc int
 	Count(sliceRoot, &nc)
 	fmt.Printf("There are %d test emails", nc)
-	// Output: There are 2379 test emails
+	// Output: There are 2387 test emails
 }


### PR DESCRIPTION
Certain email threads can have References in differing orders which can create an issue when parsing. When parsing other emails within the tree, it is possible for a node have it's parent set to an node which is already the self-node's child. For example, B has parent A and also child A. This situation creates an infinite loop in the findChild routine, resulting in a runtime panic.

Per the JWZ algorithm:
> Do not add a link if adding that link would introduce a loop: that is,
> before asserting A->B, search down the children of B to see if A is
> reachable, and also search down the children of A to see if B is
> reachable. If either is already reachable as a child of the other, don't
> add the link.

The implementation currently only inspects for B in the children of A. Add a check for A in the children of B before creating new links. Add two test emails which create a panic when threading without this check.

Update test values to reflect new threading results. Note that 6 emails in the original test suite are now included in the threads that weren't before. The passing test quantities are therefore 6 + 2 = 8 additional emails in the threaded view. See attached images for the before and after views of the threads.

## Before
![before](https://user-images.githubusercontent.com/476352/197858829-c6888366-adad-4784-b6e8-fe62141caebe.png)

## After
Note that the thread "bad focus ..." has the full tree now

![after](https://user-images.githubusercontent.com/476352/197858827-06a5aa26-0e48-4a13-9990-67fccb139ff8.png)

