### PR TITLE
fix: improve circularity detection

### DIFF
--- a/jwz_test.go
+++ b/jwz_test.go
@@ -19,6 +19,9 @@ import (
 //
 var Emails = make([]Threadable, 0, 3000)
 
+// ls -1 test/testdata/ham | wc -l
+const MessageNumber = 2405
+
 // TestMain sets up everything for the other test(s). It essentially parses a largish set of publicly available
 // Emails in to a structure that can then be used to perform email threading testing. To perform the parsing, we
 // use the enmime package at https://github.com/jhillyerd/enmime
@@ -367,12 +370,12 @@ func ExampleThreader_ThreadSlice() {
 	//
 	var nc int
 	Count(sliceRoot, &nc)
-	if nc != 2387 {
-		fmt.Printf("expected %d emails after threading, but got %d back", 2387, nc)
+	if nc != MessageNumber {
+		fmt.Printf("expected %d emails after threading, but got %d back", MessageNumber, nc)
 	} else {
 		fmt.Printf("There are %d test emails", nc)
 	}
-	// Output: There are 2387 test emails
+	// Output: There are 2405 test emails
 }
 
 func TestThreader_ThreadSlice(t1 *testing.T) {
@@ -392,8 +395,8 @@ func TestThreader_ThreadSlice(t1 *testing.T) {
 	//
 	var nc int
 	Count(sliceRoot, &nc)
-	if nc != 2387 {
-		t1.Errorf("expected %d emails after threading, but got %d back", 2387, nc)
+	if nc != MessageNumber {
+		t1.Errorf("expected %d emails after threading, but got %d back", MessageNumber, nc)
 	}
 }
 
@@ -417,12 +420,12 @@ func ExampleThreader_ThreadRoot() {
 	//
 	var nc int
 	Count(treeRoot, &nc)
-	if nc != 2387 {
-		fmt.Printf("expected %d emails afer threading, but got %d back", 2387, nc)
+	if nc != MessageNumber {
+		fmt.Printf("expected %d emails afer threading, but got %d back", MessageNumber, nc)
 	} else {
 		fmt.Printf("There are %d test emails", nc)
 	}
-	// Output: There are 2387 test emails
+	// Output: There are 2405 test emails
 }
 
 func TestThreader_ThreadRoot(t1 *testing.T) {
@@ -445,7 +448,7 @@ func TestThreader_ThreadRoot(t1 *testing.T) {
 	//
 	var nc int
 	Count(treeRoot, &nc)
-	if nc != 2387 {
-		t1.Errorf("expected %d emails after threading, but got %d back", 2387, nc)
+	if nc != MessageNumber {
+		t1.Errorf("expected %d emails after threading, but got %d back", MessageNumber, nc)
 	}
 }

--- a/threadcontainer.go
+++ b/threadcontainer.go
@@ -27,7 +27,7 @@ type threadContainer struct {
 	//
 	child *threadContainer
 
-	// child shows which threadable is the child of this container
+	// next shows which threadable is the sibling of this container
 	//
 	next *threadContainer
 
@@ -85,17 +85,14 @@ func (tc *threadContainer) flush() error {
 	return nil
 }
 
-// findChild returns true if child is under self's tree.  This is used for detecting circularities in the references header.
-//
+// findChild returns true if child is under self's tree. This is used for
+// detecting circularities in the references header.
 func (tc *threadContainer) findChild(target *threadContainer) bool {
-
-	if tc.child == nil {
-		return false
-	} else if tc.child == target {
-		return true
-	} else {
-		return tc.child.findChild(target)
+	found := false
+	for t := tc.child; t != nil; t = t.next {
+		found = found || t == target || t.findChild(target)
 	}
+	return found
 }
 
 // reverseChildren does what it implies and reverses the order of the child elements

--- a/utils_test.go
+++ b/utils_test.go
@@ -66,7 +66,7 @@ func ExampleWalk_depth() {
 
 	fmt.Printf("Walker walked %d depth first\n", c)
 
-	// Output: Walker walked 2387 depth first
+	// Output: Walker walked 2405 depth first
 }
 
 func ExampleWalk_breadth() {
@@ -97,7 +97,7 @@ func ExampleWalk_breadth() {
 
 	fmt.Printf("Walker walked %d depth first\n", c)
 
-	// Output: Walker walked 2387 depth first
+	// Output: Walker walked 2405 depth first
 }
 
 type searcher struct {
@@ -168,5 +168,5 @@ func ExampleCount() {
 	var nc int
 	Count(sliceRoot, &nc)
 	fmt.Printf("There are %d test emails", nc)
-	// Output: There are 2387 test emails
+	// Output: There are 2405 test emails
 }


### PR DESCRIPTION
Improve circularity detection in the jwz algorithm by also considering the siblings of the children. The current implementation will only follow a direct line of children but does not consider the siblings.

With this change, the threading algorithm also picks up all of the 2405 messages in the test set (counting the messages with: ls -1 test/testdata/ham | wc -l). Before, the number was hardcoded to 2387 (and there was no hint as to why the hardcoded number was lower than the total number of test messages). The examples and tests have been adjusted accordingly.